### PR TITLE
Attach source and javadoc jars for CLI and service modules

### DIFF
--- a/extractpdf4j-cli/pom.xml
+++ b/extractpdf4j-cli/pom.xml
@@ -43,6 +43,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.5.1</version>
                 <executions>

--- a/extractpdf4j-service/pom.xml
+++ b/extractpdf4j-service/pom.xml
@@ -50,6 +50,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### Motivation
- Component validation for the CLI and service modules reported missing source and Javadoc artifacts, causing publish failures.
- Maven Central (and OSSRH) require source and javadoc jars to be attached for released artifacts.
- Add lightweight plugin entries so the modules produce `-sources.jar` and `-javadoc.jar` during packaging.

### Description
- Added `maven-source-plugin` and `maven-javadoc-plugin` plugin entries to `extractpdf4j-cli/pom.xml` to attach sources and javadocs.
- Added `maven-source-plugin` and `maven-javadoc-plugin` plugin entries to `extractpdf4j-service/pom.xml` to attach sources and javadocs.
- No other functional code changes were made to the project.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695479444e6c83299f2f9e91bbfe1d3c)