### PR TITLE
Attach sources and javadocs for published modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,33 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <doclint>none</doclint>
+                    <failOnError>false</failOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -112,28 +139,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.3.0</version>
-                    <executions>
-                        <execution>
-                            <id>attach-sources</id>
-                            <goals><goal>jar</goal></goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.6.3</version>
-                    <configuration>
-                        <source>${java.version}</source>
-                        <doclint>none</doclint>
-                        <failOnError>false</failOnError>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals><goal>jar</goal></goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
### Motivation
- Maven Central validations reported missing sources and javadocs for `extractpdf4j-cli` and `extractpdf4j-service`. 
- The parent POM should produce source and javadoc jars so all modules publish proper artifacts.

### Description
- Move `maven-source-plugin` and `maven-javadoc-plugin` executions into the parent `<build><plugins>` to run `attach-sources` and `attach-javadocs` for all modules. 
- Keep plugin versions in `pluginManagement` and remove duplicated execution blocks from `pluginManagement`. 
- Add Javadoc plugin configuration (`source`, `doclint`, `failOnError`) to avoid doc build failures.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695481e9662c8329bafa5dc48c47a7a1)