### PR TITLE
Fix GitHub Pages permissions for Javadocs

### DIFF
--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -5,6 +5,8 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: "pages"
@@ -39,6 +41,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:


### PR DESCRIPTION
### Motivation
- The Javadocs publish workflow was failing with `Resource not accessible by integration` when `actions/configure-pages@v5` attempted to create the Pages site. 
- The change aims to grant the workflow the required GitHub Pages and OIDC permissions so the Pages deployment can succeed. 

### Description
- Updated ` .github/workflows/javadocs.yml` to add top-level `pages: write` and `id-token: write` permissions. 
- Ensured the `deploy` job retains `contents: read` while including `pages: write` and `id-token: write` in its `permissions`. 
- This allows `actions/configure-pages@v5` and `actions/deploy-pages@v4` to run with the necessary access to create and publish the Pages site. 

### Testing
- No automated tests were run because this is a workflow-only change. 
- The change is limited to CI workflow permissions and does not modify production code or unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c247115008329a1b5f7d5835ae0ba)