### PR TITLE
Update README versions for 2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ The copy/paste quick start is at the top of this README under the project descri
 <dependency>
   <groupId>io.github.extractpdf4j</groupId>
   <artifactId>extractpdf4j-parser</artifactId>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
 **Gradle**
 
 ```kotlin
-implementation("io.github.extractpdf4j:extractpdf4j-parser:1.0.0")
+implementation("io.github.extractpdf4j:extractpdf4j-parser:2.0.0")
 ```
 
 ### Why this vs Tabula/PDFBox (comparison table)
@@ -188,7 +188,7 @@ See also the changelog entry for this documentation pass: [CHANGELOG](CHANGELOG.
 ## Project Status
 
 - Build tool: **Maven**
-- Coordinates (current): `io.github.extractpdf4j:extractpdf4j-parser:1.0.0`
+- Coordinates (current): `io.github.extractpdf4j:extractpdf4j-parser:2.0.0`
 - Java: **17+** (recommended 17+ runtime)
 
 ## Requirements
@@ -210,14 +210,14 @@ See also the changelog entry for this documentation pass: [CHANGELOG](CHANGELOG.
 <dependency>
   <groupId>io.github.extractpdf4j</groupId>
   <artifactId>extractpdf4j-parser</artifactId>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```kotlin
-implementation("io.github.extractpdf4j:extractpdf4j-parser:1.0.0")
+implementation("io.github.extractpdf4j:extractpdf4j-parser:2.0.0")
 ```
 
 ### Native Notes


### PR DESCRIPTION
### Motivation

- Prepare project documentation for the `2.0.0` release by aligning published coordinates and dependency examples.
- Ensure install snippets and the documented artifact coordinates reflect the new major version.

### Description

- Updated `README.md` to replace `1.0.0` with `2.0.0` in Maven `<version>` snippets and documented coordinates.
- Updated `README.md` Gradle examples to reference `io.github.extractpdf4j:extractpdf4j-parser:2.0.0`.
- The change is documentation-only and limited to `README.md`.

### Testing

- No automated tests were run because this is a documentation-only change.
- A commit was created containing the `README.md` update and verified locally via `git status` and `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c307e5d88832982094bab0d538180)