### PR TITLE
build: fix Dockerfile to support multi-module project structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,16 @@
 FROM maven:3.9.2-eclipse-temurin-17 AS build
 WORKDIR /app
 COPY pom.xml .
-COPY src ./src
+
+COPY extractpdf4j-core ./extractpdf4j-core
+COPY extractpdf4j-cli ./extractpdf4j-cli
+COPY extractpdf4j-service ./extractpdf4j-service
+
 RUN mvn clean package -DskipTests
 
 # ===== Stage 2: Final Distroless image =====
 FROM gcr.io/distroless/java17-debian11
 WORKDIR /app
-COPY --from=build /app/target/extractpdf4j-parser-0.1.1.jar ./app.jar
+# =====COPY --from=build /app/target/extractpdf4j-parser-0.1.1.jar ./app.jar=====
+COPY --from=build /app/extractpdf4j-service/target/*.jar ./app.jar
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -43,10 +43,46 @@ The copy/paste quick start is at the top of this README under the project descri
 </dependency>
 ```
 
+```xml
+<dependency>
+  <groupId>io.github.extractpdf4j</groupId>
+  <artifactId>extractpdf4j-core</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+```xml
+<dependency>
+  <groupId>io.github.extractpdf4j</groupId>
+  <artifactId>extractpdf4j-cli</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+```xml
+<dependency>
+  <groupId>io.github.extractpdf4j</groupId>
+  <artifactId>extractpdf4j-service</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
 **Gradle**
 
 ```kotlin
 implementation("io.github.extractpdf4j:extractpdf4j-parser:2.0.0")
+```
+
+```kotlin
+implementation("io.github.extractpdf4j:extractpdf4j-core:2.0.0")
+```
+
+```kotlin
+implementation("io.github.extractpdf4j:extractpdf4j-cli:2.0.0")
+```
+
+```kotlin
+implementation("io.github.extractpdf4j:extractpdf4j-service:2.0.0")
 ```
 
 ### Why this vs Tabula/PDFBox (comparison table)


### PR DESCRIPTION
### Summary
The current `Dockerfile` fails to build because it attempts to copy a root `src` directory, which does not exists due to the project's multi-module structure (`extractpdf4j-core`, `service`, `cli`).

### Changes
- Updated the `COPY` commands in Stage 1 to explicitly include the `extractpdf4j-core`, `extractpdf4j-cli`, and `extractpdf4j-service` directories instead of a generic root `src`.
- Corrected the Stage 2 artifact path to locate the JAR in `/app/extractpdf4j-service/target/` instead of the root target directory.

### Verification
- **Local Build:** Ran `docker compose up --build` locally.
- **Result:** Confirmed the build completes successfully and the service starts.

### Related Issues
- Fixes broken Docker build environment.