### PR TITLE
Add full MkDocs documentation site and GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,44 @@
+name: docs-deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build docs with Material action (bundled MkDocs)
+        uses: squidfunk/mkdocs-material@v9.5.18
+        with:
+          command: build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/advanced-usage/columns.md
+++ b/docs/advanced-usage/columns.md
@@ -1,0 +1,14 @@
+# Columns
+
+Column hints can improve extraction when spacing is ambiguous.
+
+> Placeholder guidance: confirm exact API names in Javadocs before integrating.
+
+## Placeholder example
+
+```java
+// Placeholder API: adapt to actual methods if available.
+var parser = new com.extractpdf4j.parsers.StreamParser("report.pdf");
+// parser.columns("72,144,288,432");
+var tables = parser.parse();
+```

--- a/docs/advanced-usage/debug-images.md
+++ b/docs/advanced-usage/debug-images.md
@@ -1,0 +1,22 @@
+# Debug Images
+
+Debug artifacts help inspect line detection, segmentation, and OCR preprocessing.
+
+## CLI example
+
+```bash
+java -jar extractpdf4j-parser-<version>.jar input.pdf \
+  --mode lattice \
+  --debug \
+  --debug-dir debug/
+```
+
+## Java example
+
+```java
+// Placeholder method names where needed.
+var parser = new com.extractpdf4j.parsers.LatticeParser("input.pdf")
+    .dpi(300f);
+// parser.debug(true).debugDir(new java.io.File("debug"));
+var tables = parser.parse();
+```

--- a/docs/advanced-usage/ocr-tuning.md
+++ b/docs/advanced-usage/ocr-tuning.md
@@ -1,0 +1,19 @@
+# OCR Tuning
+
+For scanned/image-heavy PDFs, tuning OCR settings is often the biggest quality lever.
+
+## Recommended starting points
+
+- DPI: `300` for normal scans, `400-450` for low-quality scans
+- OCR backend: `auto` first, then force backend if needed
+- Language data: verify `TESSDATA_PREFIX`
+
+## CLI example
+
+```bash
+java -jar extractpdf4j-parser-<version>.jar scan.pdf \
+  --mode ocrstream \
+  --dpi 400 \
+  --ocr bytedeco \
+  --out out.csv
+```

--- a/docs/advanced-usage/page-ranges.md
+++ b/docs/advanced-usage/page-ranges.md
@@ -1,0 +1,19 @@
+# Page Ranges
+
+Use page filters to reduce runtime and target relevant pages only.
+
+## Common patterns
+
+- `"all"`
+- `"1"`
+- `"1-3"`
+- `"1,3-5"`
+
+## Java example
+
+```java
+// Method names shown as common patterns; verify against your current release.
+var tables = new com.extractpdf4j.parsers.HybridParser("report.pdf")
+    .pages("2-4")
+    .parse();
+```

--- a/docs/advanced-usage/table-areas.md
+++ b/docs/advanced-usage/table-areas.md
@@ -1,0 +1,20 @@
+# Table Areas
+
+Some releases may support selecting table regions explicitly.
+
+> Placeholder guidance: confirm exact API names in Javadocs before integrating.
+
+## Why constrain areas?
+
+- Ignore headers/footers
+- Improve precision on complex layouts
+- Speed up extraction by reducing search space
+
+## Placeholder example
+
+```java
+// Placeholder API: adapt to actual methods if available.
+var parser = new com.extractpdf4j.parsers.StreamParser("statement.pdf");
+// parser.tableArea("x1,y1,x2,y2");
+var tables = parser.parse();
+```

--- a/docs/api/extractor.md
+++ b/docs/api/extractor.md
@@ -1,0 +1,16 @@
+# Extractor
+
+Most integrations create a parser instance with a PDF path and call `parse()`.
+
+## Common pattern
+
+```java
+import com.extractpdf4j.helpers.Table;
+import java.util.List;
+
+// Choose parser implementation based on document characteristics.
+List<Table> tables = new com.extractpdf4j.parsers.HybridParser("input.pdf")
+    .parse();
+```
+
+> Placeholder note: constructor overloads and builder-style options may vary by version.

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,21 @@
+# Models
+
+`Table` is the central output model used across parser implementations.
+
+## Typical operations
+
+- Iterate rows/cells (API depends on release)
+- Export to CSV (`toCSV(',')` pattern in current docs)
+- Map extracted data into domain models
+
+## Example
+
+```java
+var tables = new com.extractpdf4j.parsers.HybridParser("input.pdf").parse();
+if (!tables.isEmpty()) {
+  String csv = tables.get(0).toCSV(',');
+  System.out.println(csv);
+}
+```
+
+> Placeholder note: row/cell accessor names may differ; check Javadocs for your version.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,0 +1,9 @@
+# API Overview
+
+This section maps core package concepts. Use Javadocs for exact signatures.
+
+- **Extractor entry points**: parser classes that produce `List<Table>`.
+- **Parsers**: Stream, Lattice, OCR Stream, Hybrid.
+- **Models**: table/cell abstractions and export helpers.
+
+Javadocs: <https://extractpdf4j.github.io/ExtractPDF4J/apidocs/index.html>

--- a/docs/api/parsers.md
+++ b/docs/api/parsers.md
@@ -1,0 +1,26 @@
+# Parsers
+
+## StreamParser
+Text-layer extraction for digital PDFs.
+
+## LatticeParser
+Line/grid-driven extraction for ruled tables.
+
+## OcrStreamParser
+OCR-backed extraction for image-heavy scans.
+
+## HybridParser
+Combined strategy for robust general-purpose extraction.
+
+## Example chooser
+
+```java
+String mode = "hybrid"; // stream | lattice | ocrstream | hybrid
+var parser = switch (mode) {
+  case "stream" -> new com.extractpdf4j.parsers.StreamParser("input.pdf");
+  case "lattice" -> new com.extractpdf4j.parsers.LatticeParser("input.pdf");
+  case "ocrstream" -> new com.extractpdf4j.parsers.OcrStreamParser("input.pdf");
+  default -> new com.extractpdf4j.parsers.HybridParser("input.pdf");
+};
+var tables = parser.parse();
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,29 @@
+# CLI
+
+ExtractPDF4J supports command-line extraction for scripts and pipelines.
+
+## Basic usage
+
+```bash
+java -jar extractpdf4j-parser-<version>.jar input.pdf --out tables.csv
+```
+
+## Common options
+
+- `--mode stream|lattice|ocrstream|hybrid`
+- `--pages 1|all|1,3-5`
+- `--out output.csv`
+- `--sep ,`
+- `--dpi 300`
+- `--debug`
+- `--debug-dir debug/`
+- `--ocr auto|cli|bytedeco`
+
+## Example commands
+
+```bash
+java -jar extractpdf4j-parser-<version>.jar scan.pdf --mode hybrid --dpi 400 --pages all --out scan.csv
+java -jar extractpdf4j-parser-<version>.jar statement.pdf --mode stream --pages 1-2 --out p1-2.csv
+```
+
+When `--out` is omitted, output is printed to stdout.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Thanks for improving ExtractPDF4J.
+
+## Local workflow
+
+1. Fork and clone the repo.
+2. Create a feature branch.
+3. Run tests and quality checks.
+4. Open a pull request.
+
+## Documentation contributions
+
+- Keep docs concise and developer-focused.
+- Prefer runnable Java snippets.
+- Mark uncertain signatures as placeholders.
+
+See the repository-level [CONTRIBUTING.md](../CONTRIBUTING.md) for project policies.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,15 @@
+# FAQ
+
+## Which parser should I start with?
+Use `HybridParser` first for mixed and unknown PDFs.
+
+## Does this work for scanned PDFs?
+Yes. Use OCR-backed modes (`OcrStreamParser` or `HybridParser`) and set appropriate DPI.
+
+## Why are tables empty or fragmented?
+- Increase DPI (`300–450`) for scans.
+- Try another parser mode (`stream` vs `lattice` vs `hybrid`).
+- Use debug output to inspect intermediate artifacts.
+
+## Is there a stable API reference?
+Use the hosted Javadocs for authoritative method signatures.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,26 @@
+# Getting Started
+
+This guide gives you the shortest path to extracting tables from PDFs in Java.
+
+## Prerequisites
+
+- Java 17+
+- Maven or Gradle
+- Optional OCR runtime when processing scanned/image-heavy PDFs
+
+## Pick a parser
+
+- **StreamParser**: Best for text-based PDFs.
+- **LatticeParser**: Best for ruled/gridded tables.
+- **OcrStreamParser**: Best when no text layer exists.
+- **HybridParser**: Best default for mixed documents.
+
+## Minimal flow
+
+1. Add dependency (`extractpdf4j-parser`).
+2. Instantiate parser with PDF path.
+3. Configure pages/options.
+4. Call `parse()`.
+5. Export `Table` data as CSV or process in memory.
+
+Continue to [Installation](installation.md) and [Quickstart](quickstart.md).

--- a/docs/how-it-works/hybrid.md
+++ b/docs/how-it-works/hybrid.md
@@ -1,0 +1,24 @@
+# Hybrid Parser
+
+`HybridParser` combines multiple strategies to improve resilience across mixed PDFs.
+
+## Why use it
+
+- Single default mode for unknown document characteristics
+- Handles text-based, scanned, and image-heavy pages in one flow
+
+## Java example
+
+```java
+import com.extractpdf4j.parsers.HybridParser;
+
+var tables = new HybridParser("mixed-document.pdf")
+    .pages("all")
+    .dpi(300f)
+    .parse();
+```
+
+## Notes
+
+- Great first choice in production pipelines.
+- Fine-tune by falling back to strategy-specific parsers when needed.

--- a/docs/how-it-works/lattice.md
+++ b/docs/how-it-works/lattice.md
@@ -1,0 +1,23 @@
+# Lattice Parser
+
+`LatticeParser` is designed for ruled tables where visible lines define cell boundaries.
+
+## Best for
+
+- Forms and invoices with grid lines
+- Scanned PDFs with strong table structure
+
+## Java example
+
+```java
+import com.extractpdf4j.parsers.LatticeParser;
+
+var tables = new LatticeParser("invoice_scan.pdf")
+    .dpi(300f)
+    .parse();
+```
+
+## Notes
+
+- Higher DPI can improve line detection quality.
+- Debug images are useful for tuning thresholds and cell segmentation.

--- a/docs/how-it-works/ocr-stream.md
+++ b/docs/how-it-works/ocr-stream.md
@@ -1,0 +1,23 @@
+# OCR Stream Parser
+
+`OcrStreamParser` applies OCR before stream-like grouping.
+
+## Best for
+
+- Scanned/image-heavy PDFs
+- Documents with no usable text layer
+
+## Java example
+
+```java
+import com.extractpdf4j.parsers.OcrStreamParser;
+
+var tables = new OcrStreamParser("receipt_scan.pdf")
+    .dpi(350f)
+    .parse();
+```
+
+## Notes
+
+- OCR quality strongly depends on scan quality and DPI.
+- Expect higher runtime cost than text-only stream parsing.

--- a/docs/how-it-works/overview.md
+++ b/docs/how-it-works/overview.md
@@ -1,0 +1,16 @@
+# How It Works
+
+ExtractPDF4J provides multiple extraction paths and lets you choose by document type.
+
+- **Stream**: text-position analysis from PDF text layers.
+- **Lattice**: image/grid-based cell detection.
+- **OCR Stream**: OCR text recovery + table grouping.
+- **Hybrid**: combines strategies for robust extraction.
+
+Architecture (conceptual):
+
+```text
+PDF -> parser strategy -> normalized table model -> CSV/JSON/in-memory data
+```
+
+Use strategy-specific pages in this section to pick and tune parser behavior.

--- a/docs/how-it-works/stream.md
+++ b/docs/how-it-works/stream.md
@@ -1,0 +1,23 @@
+# Stream Parser
+
+`StreamParser` is optimized for text-based PDFs with selectable text layers.
+
+## Best for
+
+- Statements and reports with consistent text alignment
+- Tables without strong border lines
+
+## Java example
+
+```java
+import com.extractpdf4j.parsers.StreamParser;
+
+var tables = new StreamParser("statement.pdf")
+    .pages("1-3")
+    .parse();
+```
+
+## Notes
+
+- Usually faster than OCR-based pipelines.
+- May struggle if text is embedded as image content.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,52 @@
+# ExtractPDF4J
+
+## Extract tables from any PDF — text-based, scanned, or image-heavy.
+
+ExtractPDF4J is a Java-native table extraction toolkit built for real-world documents.
+
+- **Text PDFs**: Use coordinate-based parsing.
+- **Scanned PDFs**: Use OCR + structure detection.
+- **Mixed PDFs**: Use hybrid extraction.
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch: **Start quickly**
+
+    ---
+
+    Install dependencies and run your first extraction in minutes.
+
+    [Getting Started](getting-started.md)
+
+-   :material-console: **Use CLI or Java API**
+
+    ---
+
+    Use the command line for fast exports, or embed parsers in your app.
+
+    [CLI Guide](cli.md)
+
+-   :material-cog-transfer: **Choose parser strategy**
+
+    ---
+
+    Stream, Lattice, OCR Stream, and Hybrid each target different PDF structures.
+
+    [How It Works](how-it-works/overview.md)
+
+</div>
+
+## Java example
+
+```java
+import com.extractpdf4j.helpers.Table;
+import com.extractpdf4j.parsers.HybridParser;
+import java.util.List;
+
+List<Table> tables = new HybridParser("sample.pdf")
+    .pages("all")
+    .dpi(300f)
+    .parse();
+```
+
+> This project evolves quickly. If method names differ in your version, treat snippets as implementation patterns.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,27 @@
+# Installation
+
+## Maven
+
+```xml
+<dependency>
+  <groupId>io.github.extractpdf4j</groupId>
+  <artifactId>extractpdf4j-parser</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+## Gradle
+
+```kotlin
+implementation("io.github.extractpdf4j:extractpdf4j-parser:2.0.0")
+```
+
+## Native dependencies notes
+
+For scanned/image-heavy PDFs, OCR/OpenCV runtime support is required.
+
+- Recommended: Bytedeco `*-platform` artifacts.
+- If using system installs, ensure native library paths are configured.
+- Set `TESSDATA_PREFIX` when Tesseract language packs are not auto-detected.
+
+See [OCR tuning](advanced-usage/ocr-tuning.md) for practical settings.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart
+
+## Hybrid mode (recommended default)
+
+```java
+import com.extractpdf4j.helpers.Table;
+import com.extractpdf4j.parsers.HybridParser;
+import java.util.List;
+
+List<Table> tables = new HybridParser("invoices.pdf")
+    .pages("all")
+    .dpi(300f)
+    .parse();
+
+if (!tables.isEmpty()) {
+  System.out.println(tables.get(0).toCSV(','));
+}
+```
+
+## Text-based documents
+
+```java
+import com.extractpdf4j.parsers.StreamParser;
+
+var tables = new StreamParser("statement.pdf")
+    .pages("1-3")
+    .parse();
+```
+
+## Scanned or image-heavy documents
+
+```java
+import com.extractpdf4j.parsers.OcrStreamParser;
+
+var tables = new OcrStreamParser("scan.pdf")
+    .dpi(300f)
+    .parse();
+```
+
+> If your installed version has different method names, adapt these snippets accordingly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,55 @@
+site_name: ExtractPDF4J Docs
+site_description: Java-native PDF table extraction for text-based, scanned, and image-heavy PDFs.
+site_url: https://extractpdf4j.github.io/ExtractPDF4J/
+repo_url: https://github.com/ExtractPDF4J/ExtractPDF4J
+repo_name: ExtractPDF4J/ExtractPDF4J
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: blue
+      accent: indigo
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.superfences
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Installation: installation.md
+  - Quickstart: quickstart.md
+  - CLI: cli.md
+  - How It Works:
+      - Overview: how-it-works/overview.md
+      - Stream Parser: how-it-works/stream.md
+      - Lattice Parser: how-it-works/lattice.md
+      - OCR Stream Parser: how-it-works/ocr-stream.md
+      - Hybrid Parser: how-it-works/hybrid.md
+  - Advanced Usage:
+      - Page Ranges: advanced-usage/page-ranges.md
+      - Table Areas: advanced-usage/table-areas.md
+      - Columns: advanced-usage/columns.md
+      - OCR Tuning: advanced-usage/ocr-tuning.md
+      - Debug Images: advanced-usage/debug-images.md
+  - API Reference:
+      - Overview: api/overview.md
+      - Extractor: api/extractor.md
+      - Parsers: api/parsers.md
+      - Models: api/models.md
+  - FAQ: faq.md
+  - Contributing: contributing.md


### PR DESCRIPTION
### Motivation

- Provide a first-class documentation site with examples, API guides, and tuning notes to help users adopt the library. 
- Centralize docs content and navigation so contributors can submit focused docs changes. 
- Enable automated site build and deployment to GitHub Pages.

### Description

- Added a complete set of documentation pages under `docs/` including Getting Started, Quickstart, CLI, API reference, How It Works, Advanced Usage, FAQ, and Contributing. 
- Added `mkdocs.yml` to configure the MkDocs Material theme, site navigation, and markdown extensions. 
- Added a GitHub Actions workflow `/.github/workflows/docs-deploy.yml` that builds the site with `squidfunk/mkdocs-material` using `command: build --strict` and deploys to GitHub Pages with `actions/deploy-pages@v4`. 
- Included placeholder code snippets and notes where API method names may vary between releases to guide integration and future refinement.

### Testing

- No automated unit or integration tests were executed as part of this PR. 
- The new GitHub Actions workflow will run `mkdocs build --strict` and deploy the site on pushes to `main`, which will validate the documentation build when triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a649d9786083298e5ff32145452672)