### PR TITLE
Add full MkDocs documentation and GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,44 @@
+name: docs-deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build docs with Material action (bundled MkDocs)
+        uses: squidfunk/mkdocs-material@v9.5.18
+        with:
+          command: build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/advanced-usage/columns.md
+++ b/docs/advanced-usage/columns.md
@@ -1,0 +1,14 @@
+# Columns
+
+Column hints can improve extraction when spacing is ambiguous.
+
+> Placeholder guidance: confirm exact API names in Javadocs before integrating.
+
+## Placeholder example
+
+```java
+// Placeholder API: adapt to actual methods if available.
+var parser = new com.extractpdf4j.parsers.StreamParser("report.pdf");
+// parser.columns("72,144,288,432");
+var tables = parser.parse();
+```

--- a/docs/advanced-usage/debug-images.md
+++ b/docs/advanced-usage/debug-images.md
@@ -1,0 +1,22 @@
+# Debug Images
+
+Debug artifacts help inspect line detection, segmentation, and OCR preprocessing.
+
+## CLI example
+
+```bash
+java -jar extractpdf4j-parser-<version>.jar input.pdf \
+  --mode lattice \
+  --debug \
+  --debug-dir debug/
+```
+
+## Java example
+
+```java
+// Placeholder method names where needed.
+var parser = new com.extractpdf4j.parsers.LatticeParser("input.pdf")
+    .dpi(300f);
+// parser.debug(true).debugDir(new java.io.File("debug"));
+var tables = parser.parse();
+```

--- a/docs/advanced-usage/ocr-tuning.md
+++ b/docs/advanced-usage/ocr-tuning.md
@@ -1,0 +1,19 @@
+# OCR Tuning
+
+For scanned/image-heavy PDFs, tuning OCR settings is often the biggest quality lever.
+
+## Recommended starting points
+
+- DPI: `300` for normal scans, `400-450` for low-quality scans
+- OCR backend: `auto` first, then force backend if needed
+- Language data: verify `TESSDATA_PREFIX`
+
+## CLI example
+
+```bash
+java -jar extractpdf4j-parser-<version>.jar scan.pdf \
+  --mode ocrstream \
+  --dpi 400 \
+  --ocr bytedeco \
+  --out out.csv
+```

--- a/docs/advanced-usage/page-ranges.md
+++ b/docs/advanced-usage/page-ranges.md
@@ -1,0 +1,19 @@
+# Page Ranges
+
+Use page filters to reduce runtime and target relevant pages only.
+
+## Common patterns
+
+- `"all"`
+- `"1"`
+- `"1-3"`
+- `"1,3-5"`
+
+## Java example
+
+```java
+// Method names shown as common patterns; verify against your current release.
+var tables = new com.extractpdf4j.parsers.HybridParser("report.pdf")
+    .pages("2-4")
+    .parse();
+```

--- a/docs/advanced-usage/table-areas.md
+++ b/docs/advanced-usage/table-areas.md
@@ -1,0 +1,20 @@
+# Table Areas
+
+Some releases may support selecting table regions explicitly.
+
+> Placeholder guidance: confirm exact API names in Javadocs before integrating.
+
+## Why constrain areas?
+
+- Ignore headers/footers
+- Improve precision on complex layouts
+- Speed up extraction by reducing search space
+
+## Placeholder example
+
+```java
+// Placeholder API: adapt to actual methods if available.
+var parser = new com.extractpdf4j.parsers.StreamParser("statement.pdf");
+// parser.tableArea("x1,y1,x2,y2");
+var tables = parser.parse();
+```

--- a/docs/api/extractor.md
+++ b/docs/api/extractor.md
@@ -1,0 +1,16 @@
+# Extractor
+
+Most integrations create a parser instance with a PDF path and call `parse()`.
+
+## Common pattern
+
+```java
+import com.extractpdf4j.helpers.Table;
+import java.util.List;
+
+// Choose parser implementation based on document characteristics.
+List<Table> tables = new com.extractpdf4j.parsers.HybridParser("input.pdf")
+    .parse();
+```
+
+> Placeholder note: constructor overloads and builder-style options may vary by version.

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,21 @@
+# Models
+
+`Table` is the central output model used across parser implementations.
+
+## Typical operations
+
+- Iterate rows/cells (API depends on release)
+- Export to CSV (`toCSV(',')` pattern in current docs)
+- Map extracted data into domain models
+
+## Example
+
+```java
+var tables = new com.extractpdf4j.parsers.HybridParser("input.pdf").parse();
+if (!tables.isEmpty()) {
+  String csv = tables.get(0).toCSV(',');
+  System.out.println(csv);
+}
+```
+
+> Placeholder note: row/cell accessor names may differ; check Javadocs for your version.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,0 +1,9 @@
+# API Overview
+
+This section maps core package concepts. Use Javadocs for exact signatures.
+
+- **Extractor entry points**: parser classes that produce `List<Table>`.
+- **Parsers**: Stream, Lattice, OCR Stream, Hybrid.
+- **Models**: table/cell abstractions and export helpers.
+
+Javadocs: <https://extractpdf4j.github.io/ExtractPDF4J/apidocs/index.html>

--- a/docs/api/parsers.md
+++ b/docs/api/parsers.md
@@ -1,0 +1,26 @@
+# Parsers
+
+## StreamParser
+Text-layer extraction for digital PDFs.
+
+## LatticeParser
+Line/grid-driven extraction for ruled tables.
+
+## OcrStreamParser
+OCR-backed extraction for image-heavy scans.
+
+## HybridParser
+Combined strategy for robust general-purpose extraction.
+
+## Example chooser
+
+```java
+String mode = "hybrid"; // stream | lattice | ocrstream | hybrid
+var parser = switch (mode) {
+  case "stream" -> new com.extractpdf4j.parsers.StreamParser("input.pdf");
+  case "lattice" -> new com.extractpdf4j.parsers.LatticeParser("input.pdf");
+  case "ocrstream" -> new com.extractpdf4j.parsers.OcrStreamParser("input.pdf");
+  default -> new com.extractpdf4j.parsers.HybridParser("input.pdf");
+};
+var tables = parser.parse();
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,40 @@
+# CLI
+
+The CLI is useful for automation, one-off conversions, and data pipeline pre-processing.
+
+## Usage
+
+```bash
+java -jar extractpdf4j-parser-<version>.jar <pdf> \
+  [--mode stream|lattice|ocrstream|hybrid] \
+  [--pages 1|all|1,3-5] \
+  [--sep ,] \
+  [--out out.csv] \
+  [--debug] \
+  [--dpi 300] \
+  [--ocr auto|cli|bytedeco] \
+  [--keep-cells] \
+  [--debug-dir <dir>] \
+  [--min-score 0-1] \
+  [--require-headers Date,Description,Balance]
+```
+
+## Important options
+
+- `--mode`: parser strategy; default behavior is typically hybrid.
+- `--pages`: accepts `"1"`, `"1-3"`, `"1,3-5"`, or `"all"`.
+- `--dpi`: commonly `300-450` for scanned documents.
+- `--debug` + `--debug-dir`: emit intermediate images for troubleshooting.
+- `--ocr`: choose OCR backend (`auto`, `cli`, `bytedeco`).
+
+## Example commands
+
+```bash
+java -jar extractpdf4j-parser-<version>.jar scan.pdf --mode lattice --pages 1 --dpi 450 --ocr cli --debug --keep-cells --debug-dir debug_out --out p1.csv
+java -jar extractpdf4j-parser-<version>.jar statement.pdf --mode hybrid --pages all --dpi 400 --out tables.csv
+```
+
+## Output behavior
+
+- When `--out` is omitted, CSV is printed to stdout.
+- With multiple tables, file outputs are suffixed (for example: `out-1.csv`, `out-2.csv`).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Thanks for improving ExtractPDF4J.
+
+## Local workflow
+
+1. Fork and clone the repo.
+2. Create a feature branch.
+3. Run tests and quality checks.
+4. Open a pull request.
+
+## Documentation contributions
+
+- Keep docs concise and developer-focused.
+- Prefer runnable Java snippets.
+- Mark uncertain signatures as placeholders.
+
+See the repository-level [CONTRIBUTING.md](../CONTRIBUTING.md) for project policies.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,21 @@
+# FAQ
+
+## Which parser should I start with?
+Start with `HybridParser` for unknown/mixed inputs, then specialize if needed.
+
+## Does this work for scanned PDFs?
+Yes. Use `OcrStreamParser` or `HybridParser`, and raise DPI (often `300-450`).
+
+## Why are extracted tables fragmented?
+Try the following:
+
+1. Increase DPI for scanned sources.
+2. Switch parser mode (`stream`, `lattice`, `ocrstream`, `hybrid`).
+3. Enable debug artifacts and inspect segmentation outputs.
+4. Limit pages to avoid noisy sections (covers/appendices).
+
+## Is this only for CSV export?
+No. CSV is convenient, but parser results are available as in-memory table models for application-level transformation.
+
+## Where are exact method signatures documented?
+Use the project Javadocs as the source of truth for your release version.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,48 @@
+# Getting Started
+
+ExtractPDF4J is designed for Java teams that need table extraction from:
+
+- **text-based PDFs** (digital statements/reports)
+- **scanned PDFs** (image pages)
+- **image-heavy/mixed PDFs** (hybrid extraction scenarios)
+
+## What problem it solves
+
+Many PDF workflows fail when documents do not have a clean text layer.
+ExtractPDF4J provides parser strategies that handle both coordinate-based text extraction and OCR-assisted extraction.
+
+## Choose a parser mode
+
+| Parser | Best for | Typical tradeoff |
+| --- | --- | --- |
+| `StreamParser` | Text-based PDFs with selectable text | Fast, but depends on text layer quality |
+| `LatticeParser` | Ruled/gridded tables, many scanned statements | Needs stronger line structure |
+| `OcrStreamParser` | Scanned/image-heavy documents with weak/no text layer | Higher runtime due to OCR |
+| `HybridParser` | Mixed or unknown PDF types | Most robust default |
+
+## Minimal flow
+
+1. Add dependency (`extractpdf4j-parser`).
+2. Instantiate parser with PDF path.
+3. Set page range and optional tuning (DPI/debug/OCR backend).
+4. Call `parse()`.
+5. Export table data as CSV or map to your domain models.
+
+## First Java snippet
+
+```java
+import com.extractpdf4j.helpers.Table;
+import com.extractpdf4j.parsers.HybridParser;
+import java.util.List;
+
+List<Table> tables = new HybridParser("scanned_invoice.pdf")
+    .pages("all")
+    .dpi(300f)
+    .parse();
+
+if (!tables.isEmpty()) {
+  System.out.println(tables.get(0).toCSV(','));
+}
+```
+
+Next: [Installation](installation.md) → [Quickstart](quickstart.md).

--- a/docs/how-it-works/hybrid.md
+++ b/docs/how-it-works/hybrid.md
@@ -1,0 +1,24 @@
+# Hybrid Parser
+
+`HybridParser` combines multiple strategies to improve resilience across mixed PDFs.
+
+## Why use it
+
+- Single default mode for unknown document characteristics
+- Handles text-based, scanned, and image-heavy pages in one flow
+
+## Java example
+
+```java
+import com.extractpdf4j.parsers.HybridParser;
+
+var tables = new HybridParser("mixed-document.pdf")
+    .pages("all")
+    .dpi(300f)
+    .parse();
+```
+
+## Notes
+
+- Great first choice in production pipelines.
+- Fine-tune by falling back to strategy-specific parsers when needed.

--- a/docs/how-it-works/lattice.md
+++ b/docs/how-it-works/lattice.md
@@ -1,0 +1,23 @@
+# Lattice Parser
+
+`LatticeParser` is designed for ruled tables where visible lines define cell boundaries.
+
+## Best for
+
+- Forms and invoices with grid lines
+- Scanned PDFs with strong table structure
+
+## Java example
+
+```java
+import com.extractpdf4j.parsers.LatticeParser;
+
+var tables = new LatticeParser("invoice_scan.pdf")
+    .dpi(300f)
+    .parse();
+```
+
+## Notes
+
+- Higher DPI can improve line detection quality.
+- Debug images are useful for tuning thresholds and cell segmentation.

--- a/docs/how-it-works/ocr-stream.md
+++ b/docs/how-it-works/ocr-stream.md
@@ -1,0 +1,23 @@
+# OCR Stream Parser
+
+`OcrStreamParser` applies OCR before stream-like grouping.
+
+## Best for
+
+- Scanned/image-heavy PDFs
+- Documents with no usable text layer
+
+## Java example
+
+```java
+import com.extractpdf4j.parsers.OcrStreamParser;
+
+var tables = new OcrStreamParser("receipt_scan.pdf")
+    .dpi(350f)
+    .parse();
+```
+
+## Notes
+
+- OCR quality strongly depends on scan quality and DPI.
+- Expect higher runtime cost than text-only stream parsing.

--- a/docs/how-it-works/overview.md
+++ b/docs/how-it-works/overview.md
@@ -1,0 +1,27 @@
+# How It Works
+
+ExtractPDF4J applies different extraction strategies and returns normalized `Table` outputs.
+
+## Conceptual architecture
+
+```text
+PDF (text-based) -> Stream parsing (text coordinates) ----\
+                                                           > normalized table model -> CSV/in-memory processing
+PDF (scanned/image-heavy) -> image processing + OCR -----/
+```
+
+## Strategy summary
+
+- **Stream**: uses text positioning from PDF text layers.
+- **Lattice**: detects table structure from lines/grids in rendered page images.
+- **OCR Stream**: OCR-first extraction for pages with missing text layer.
+- **Hybrid**: combines modes to improve resilience across diverse page types.
+
+## Core parser flow
+
+1. Load PDF and select pages.
+2. Apply chosen strategy.
+3. Build table cells/rows.
+4. Return `List<Table>` for export or mapping.
+
+See mode-specific pages for tuning guidance.

--- a/docs/how-it-works/stream.md
+++ b/docs/how-it-works/stream.md
@@ -1,0 +1,23 @@
+# Stream Parser
+
+`StreamParser` is optimized for text-based PDFs with selectable text layers.
+
+## Best for
+
+- Statements and reports with consistent text alignment
+- Tables without strong border lines
+
+## Java example
+
+```java
+import com.extractpdf4j.parsers.StreamParser;
+
+var tables = new StreamParser("statement.pdf")
+    .pages("1-3")
+    .parse();
+```
+
+## Notes
+
+- Usually faster than OCR-based pipelines.
+- May struggle if text is embedded as image content.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,59 @@
+# ExtractPDF4J
+
+## Java-native table extraction for text-based, scanned, and image-heavy PDFs.
+
+Build reliable table extraction pipelines for statements, invoices, forms, and mixed-quality PDFs.
+
+- **Text-based PDFs**: Coordinate-aware stream parsing.
+- **Scanned PDFs**: OCR-assisted extraction.
+- **Image-heavy PDFs**: Hybrid strategy for robust fallback behavior.
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch: **Get productive fast**
+
+    ---
+
+    Install and run your first extraction in minutes.
+
+    [Getting Started](getting-started.md)
+
+-   :material-console: **CLI + Java API**
+
+    ---
+
+    Automate with CLI or embed parsers directly in Java services.
+
+    [CLI Guide](cli.md)
+
+-   :material-cog-transfer: **Parser strategies**
+
+    ---
+
+    Learn when to use Stream, Lattice, OCR Stream, or Hybrid.
+
+    [How It Works](how-it-works/overview.md)
+
+</div>
+
+## Quick Java snippet
+
+```java
+import com.extractpdf4j.helpers.Table;
+import com.extractpdf4j.parsers.HybridParser;
+import java.util.List;
+
+List<Table> tables = new HybridParser("sample.pdf")
+    .pages("all")
+    .dpi(300f)
+    .parse();
+```
+
+## Why teams choose ExtractPDF4J
+
+| Capability | ExtractPDF4J |
+| --- | --- |
+| Text PDFs | ✅ |
+| Scanned/Image PDFs | ✅ Native OCR support |
+| Multiple strategies | ✅ Stream, Lattice, OCR Stream, Hybrid |
+| Java-first integration | ✅ |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,59 @@
+# Installation
+
+## Java and build requirements
+
+- Java 17+
+- Maven or Gradle
+- OCR/OpenCV runtime support for scanned/image-heavy workflows
+
+## Maven coordinates
+
+### Parser (primary dependency)
+
+```xml
+<dependency>
+  <groupId>io.github.extractpdf4j</groupId>
+  <artifactId>extractpdf4j-parser</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+### Other published modules
+
+```xml
+<dependency>
+  <groupId>io.github.extractpdf4j</groupId>
+  <artifactId>extractpdf4j-core</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+```xml
+<dependency>
+  <groupId>io.github.extractpdf4j</groupId>
+  <artifactId>extractpdf4j-cli</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+```xml
+<dependency>
+  <groupId>io.github.extractpdf4j</groupId>
+  <artifactId>extractpdf4j-service</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+## Gradle
+
+```kotlin
+implementation("io.github.extractpdf4j:extractpdf4j-parser:2.0.0")
+```
+
+## Native/OCR notes
+
+- Recommended approach: use Bytedeco `*-platform` artifacts where possible.
+- If using system-level installs, ensure native library paths are configured for your OS (`LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH`, or Windows `PATH`).
+- Set `TESSDATA_PREFIX` if OCR language data is not auto-discovered.
+
+See [OCR tuning](advanced-usage/ocr-tuning.md) for practical defaults.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart
+
+## 1) Recommended default: Hybrid parser
+
+Use hybrid mode when document type is unknown or mixed (text + scans).
+
+```java
+import com.extractpdf4j.helpers.Table;
+import com.extractpdf4j.parsers.HybridParser;
+import java.util.List;
+
+List<Table> tables = new HybridParser("invoices.pdf")
+    .pages("all")
+    .dpi(300f)
+    .parse();
+
+if (!tables.isEmpty()) {
+  System.out.println(tables.get(0).toCSV(','));
+}
+```
+
+## 2) Text-based PDFs: Stream parser
+
+```java
+import com.extractpdf4j.parsers.StreamParser;
+
+var tables = new StreamParser("statement.pdf")
+    .pages("1-3")
+    .parse();
+```
+
+## 3) Scanned/image-heavy PDFs: OCR stream parser
+
+```java
+import com.extractpdf4j.parsers.OcrStreamParser;
+
+var tables = new OcrStreamParser("scan.pdf")
+    .dpi(300f)
+    .pages("1-2")
+    .parse();
+```
+
+## 4) Batch extraction example
+
+```java
+import com.extractpdf4j.helpers.Table;
+import com.extractpdf4j.parsers.HybridParser;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+for (File pdf : new File("./invoices").listFiles(f -> f.getName().endsWith(".pdf"))) {
+  List<Table> tables = new HybridParser(pdf.getPath()).dpi(300f).parse();
+  if (!tables.isEmpty()) {
+    Files.writeString(Path.of("./out/" + pdf.getName() + ".csv"), tables.get(0).toCSV(','));
+  }
+}
+```
+
+> If your installed version has different method names, adapt snippets to your release Javadocs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,55 @@
+site_name: ExtractPDF4J Docs
+site_description: Java-native PDF table extraction for text-based, scanned, and image-heavy PDFs.
+site_url: https://extractpdf4j.github.io/ExtractPDF4J/
+repo_url: https://github.com/ExtractPDF4J/ExtractPDF4J
+repo_name: ExtractPDF4J/ExtractPDF4J
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: blue
+      accent: indigo
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.superfences
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Installation: installation.md
+  - Quickstart: quickstart.md
+  - CLI: cli.md
+  - How It Works:
+      - Overview: how-it-works/overview.md
+      - Stream Parser: how-it-works/stream.md
+      - Lattice Parser: how-it-works/lattice.md
+      - OCR Stream Parser: how-it-works/ocr-stream.md
+      - Hybrid Parser: how-it-works/hybrid.md
+  - Advanced Usage:
+      - Page Ranges: advanced-usage/page-ranges.md
+      - Table Areas: advanced-usage/table-areas.md
+      - Columns: advanced-usage/columns.md
+      - OCR Tuning: advanced-usage/ocr-tuning.md
+      - Debug Images: advanced-usage/debug-images.md
+  - API Reference:
+      - Overview: api/overview.md
+      - Extractor: api/extractor.md
+      - Parsers: api/parsers.md
+      - Models: api/models.md
+  - FAQ: faq.md
+  - Contributing: contributing.md


### PR DESCRIPTION
### Motivation

- Provide a first-class documentation site for ExtractPDF4J covering getting started, CLI, API overview, parser guides, and advanced usage.
- Consolidate examples, troubleshooting, and installation guidance to help developers integrate the library quickly.
- Automate docs publishing via GitHub Pages so the site is built and deployed on changes to `main`.

### Description

- Add `mkdocs.yml` configured to use the Material theme and a structured navigation for the docs site.
- Add comprehensive documentation pages under `docs/` including `index.md`, `getting-started.md`, `installation.md`, `quickstart.md`, `cli.md`, `faq.md`, `contributing.md`, `how-it-works/*`, `api/*`, and `advanced-usage/*`.
- Add GitHub Actions workflow `.github/workflows/docs-deploy.yml` that runs `mkdocs build --strict` via the Material action, uploads the site artifact, and deploys using `actions/deploy-pages@v4`.
- Include placeholder notes in code snippets to indicate that exact API signatures should be verified against Javadocs for each release.

### Testing

- Continuous integration for the docs is configured via the new `docs-deploy` workflow to run `mkdocs build --strict` and deploy to GitHub Pages on pushes to `main` and manual dispatch; the workflow is added but not run by this PR itself.
- No repository unit or integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a649d9786083298e5ff32145452672)