### PR TITLE
Docs: add docs development guide, update README and MkDocs CI to v9

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build docs with Material action (bundled MkDocs)
-        uses: squidfunk/mkdocs-material@v9.5.18
+        uses: squidfunk/mkdocs-material@v9
         with:
           command: build --strict
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,29 @@ implementation("io.github.extractpdf4j:extractpdf4j-service:2.0.0")
 
 ---
 
+
+## Documentation
+
+Project documentation lives in [`/docs`](./docs) and is published to GitHub Pages.
+For contributor-focused MkDocs workflow details, see [`docs/docs-development.md`](./docs/docs-development.md).
+
+### Build docs locally
+
+```bash
+pip install mkdocs-material
+mkdocs build --strict
+```
+
+### Serve docs locally
+
+```bash
+mkdocs serve
+```
+
+The CI workflow uses `squidfunk/mkdocs-material@v9` so docs builds track the latest v9 patch releases and avoid pinning to unavailable tags.
+
+---
+
 ### Why this vs Tabula/PDFBox (comparison table)
 
 | Feature | ExtractPDF4J | Tabula-Java | PDFBox |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,6 +13,9 @@ Thanks for improving ExtractPDF4J.
 
 - Keep docs concise and developer-focused.
 - Prefer runnable Java snippets.
+- Keep README and MkDocs pages consistent for setup/build instructions.
 - Mark uncertain signatures as placeholders.
+
+For detailed docs workflow (local build, local serve, and CI behavior), see [Documentation Development](docs-development.md).
 
 See the repository-level [CONTRIBUTING.md](../CONTRIBUTING.md) for project policies.

--- a/docs/docs-development.md
+++ b/docs/docs-development.md
@@ -1,0 +1,57 @@
+# Documentation Development
+
+This page explains how to work on the MkDocs site locally and how documentation is built in CI.
+
+## Where docs live
+
+- Source pages: [`/docs`](./)
+- Site config: [`mkdocs.yml`](../mkdocs.yml)
+- Deployment workflow: [`.github/workflows/docs-deploy.yml`](../.github/workflows/docs-deploy.yml)
+
+## Local prerequisites
+
+- Python 3.9+
+- `pip`
+
+Install MkDocs Material:
+
+```bash
+pip install mkdocs-material
+```
+
+## Build docs locally
+
+Run a strict docs build (same behavior used in CI):
+
+```bash
+mkdocs build --strict
+```
+
+## Serve docs locally
+
+Start a local preview server:
+
+```bash
+mkdocs serve
+```
+
+Default URL:
+
+- http://127.0.0.1:8000
+
+## CI behavior (GitHub Actions)
+
+Docs are built in GitHub Actions using the Material-maintained action:
+
+```yaml
+- name: Build docs with Material action (bundled MkDocs)
+  uses: squidfunk/mkdocs-material@v9
+  with:
+    command: build --strict
+```
+
+Why `@v9`?
+
+- It tracks stable v9 patch updates.
+- It avoids hard-pinning to a patch ref that may not exist.
+- It keeps CI behavior aligned with the local `mkdocs build --strict` command documented in the README.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,3 +53,4 @@ nav:
       - Models: api/models.md
   - FAQ: faq.md
   - Contributing: contributing.md
+  - Docs Development: docs-development.md


### PR DESCRIPTION
### Motivation
- Centralize contributor-facing documentation about building and serving the MkDocs site locally and explain CI behavior. 
- Avoid CI failures caused by pinning to a specific patch tag for the Material action by moving to a stable `v9` channel. 
- Make the README and `docs` content consistent about how to build and serve docs locally. 

### Description
- Added a new `docs/docs-development.md` with local prerequisites, build/serve commands, and CI behavior for the MkDocs site. 
- Updated `README.md` to include a "Documentation" section that documents local build/serve steps and notes the CI uses `squidfunk/mkdocs-material@v9`. 
- Updated `docs/contributing.md` to reference the docs workflow and reinforce README/MkDocs consistency. 
- Updated `mkdocs.yml` navigation to include the new `docs-development.md` page and changed `.github/workflows/docs-deploy.yml` to use `squidfunk/mkdocs-material@v9` for the build step. 

### Testing
- Ran a local docs build with `mkdocs build --strict` which completed successfully. 
- No functional unit tests were changed or required for these documentation-only updates. 
- CI docs workflow change is limited to switching the action tag to `@v9`; existing workflow behavior remains `mkdocs build --strict`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64e497080832984041e3d08676455)