### PR TITLE
Fix docs deploy workflow action reference for MkDocs Material

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build docs with Material action (bundled MkDocs)
-        uses: squidfunk/mkdocs-material@v9
+        uses: squidfunk/mkdocs-material@master
         with:
           command: build --strict
 


### PR DESCRIPTION
### Motivation
- GitHub Actions could not resolve `squidfunk/mkdocs-material@v9` because the action does not provide a `v9` tag, which prevented the docs build step from running.

### Description
- Replace `squidfunk/mkdocs-material@v9` with `squidfunk/mkdocs-material@master` in `.github/workflows/docs-deploy.yml` to reference a valid ref for the Material action.

### Testing
- Ran `rg -n "squidfunk/mkdocs-material@v9|mkdocs-material" .github` to locate the usage (succeeded), `git diff -- .github/workflows/docs-deploy.yml` to confirm the patch (succeeded), and `nl -ba .github/workflows/docs-deploy.yml | sed -n '18,40p'` to verify the updated line (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a650b82d9483298eb1644e3ea44bc8)