### PR TITLE
Pin MkDocs 1.x dependencies and update docs build workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -22,10 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build docs with Material action (bundled MkDocs)
-        uses: squidfunk/mkdocs-material@master
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          command: build --strict
+          python-version: '3.11'
+
+      - name: Install docs dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build docs
+        run: mkdocs build --strict
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ For contributor-focused MkDocs workflow details, see [`docs/docs-development.md`
 ### Build docs locally
 
 ```bash
-pip install mkdocs-material
+pip install -r docs/requirements.txt
 mkdocs build --strict
 ```
 
@@ -178,7 +178,7 @@ mkdocs build --strict
 mkdocs serve
 ```
 
-The CI workflow uses `squidfunk/mkdocs-material@v9` so docs builds track the latest v9 patch releases and avoid pinning to unavailable tags.
+Docs dependencies are pinned to MkDocs 1.x in [`docs/requirements.txt`](./docs/requirements.txt) because MkDocs 2.0 currently warns as incompatible with Material for MkDocs.
 
 ---
 

--- a/docs/docs-development.md
+++ b/docs/docs-development.md
@@ -16,7 +16,7 @@ This page explains how to work on the MkDocs site locally and how documentation 
 Install MkDocs Material:
 
 ```bash
-pip install mkdocs-material
+pip install -r docs/requirements.txt
 ```
 
 ## Build docs locally
@@ -41,17 +41,23 @@ Default URL:
 
 ## CI behavior (GitHub Actions)
 
-Docs are built in GitHub Actions using the Material-maintained action:
+Docs are built in GitHub Actions with Python + pinned docs dependencies:
 
 ```yaml
-- name: Build docs with Material action (bundled MkDocs)
-  uses: squidfunk/mkdocs-material@v9
+- name: Set up Python
+  uses: actions/setup-python@v5
   with:
-    command: build --strict
+    python-version: '3.11'
+
+- name: Install docs dependencies
+  run: pip install -r docs/requirements.txt
+
+- name: Build docs
+  run: mkdocs build --strict
 ```
 
-Why `@v9`?
+Why pinned requirements?
 
-- It tracks stable v9 patch updates.
-- It avoids hard-pinning to a patch ref that may not exist.
-- It keeps CI behavior aligned with the local `mkdocs build --strict` command documented in the README.
+- They keep local and CI behavior aligned.
+- They avoid pulling MkDocs 2.0 while Material for MkDocs reports incompatibility warnings.
+- They preserve strict docs builds with predictable versions.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.6,<2.0
+mkdocs-material>=9,<10


### PR DESCRIPTION
### Motivation
- Prevent accidental upgrade to MkDocs 2.0 which currently triggers incompatibility warnings with Material for MkDocs.
- Ensure local developer instructions and CI use the same, predictable docs tool versions to preserve `mkdocs build --strict` behavior. 
- Make the docs toolchain explicit and reproducible by pinning versions in a single `docs/requirements.txt` file.

### Description
- Add `docs/requirements.txt` with `mkdocs>=1.6,<2.0` and `mkdocs-material>=9,<10` to pin docs dependencies. 
- Update `README.md` to instruct local installs via `pip install -r docs/requirements.txt` before running `mkdocs build --strict`. 
- Update `docs/docs-development.md` to use the shared requirements file for local setup and to document the CI approach and rationale. 
- Replace the `squidfunk/mkdocs-material` action in `.github/workflows/docs-deploy.yml` with an explicit Python setup, `pip install -r docs/requirements.txt`, and `mkdocs build --strict` steps. 

### Testing
- Ran `python3 -m pip install -r docs/requirements.txt` which failed in this environment due to package index/proxy access (`403 Forbidden`).
- Ran `mkdocs --version` which failed because `mkdocs` is not installed in the current environment, so a local `mkdocs build --strict` could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6526fc6cc83298931d16b9e0d3959)