### PR TITLE
docs: align module and CLI artifact references

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
     <img src="https://img.shields.io/badge/Java-17%2B-1976D2?style=for-the-badge&logo=openjdk&logoColor=white" alt="Java 17+" />
   </a>
   <a href="https://github.com/ExtractPDF4J/ExtractPDF4J/releases/tag/v2.1.0">
-  <img src="https://img.shields.io/badge/release-v2.0.0-616161?style=for-the-badge" alt="Release v2.1.0" />
+  <img src="https://img.shields.io/badge/release-v2.1.0-616161?style=for-the-badge" alt="Release v2.1.0" />
   </a>
   <a href="https://github.com/ExtractPDF4J/ExtractPDF4J">
     <img src="https://img.shields.io/badge/OCR-supported-5E35B1?style=for-the-badge" alt="OCR Supported" />
@@ -156,14 +156,6 @@ If you prefer not to use the BOM:
 ```xml
 <dependency>
   <groupId>io.github.extractpdf4j</groupId>
-  <artifactId>extractpdf4j-parser</artifactId>
-  <version>2.1.0</version>
-</dependency>
-```
-
-```xml
-<dependency>
-  <groupId>io.github.extractpdf4j</groupId>
   <artifactId>extractpdf4j-core</artifactId>
   <version>2.1.0</version>
 </dependency>
@@ -188,19 +180,15 @@ If you prefer not to use the BOM:
 ### **Gradle**
 
 ```kotlin
-implementation("io.github.extractpdf4j:extractpdf4j-parser:2.0.0")
+implementation("io.github.extractpdf4j:extractpdf4j-core:2.1.0")
 ```
 
 ```kotlin
-implementation("io.github.extractpdf4j:extractpdf4j-core:2.0.0")
+implementation("io.github.extractpdf4j:extractpdf4j-cli:2.1.0")
 ```
 
 ```kotlin
-implementation("io.github.extractpdf4j:extractpdf4j-cli:2.0.0")
-```
-
-```kotlin
-implementation("io.github.extractpdf4j:extractpdf4j-service:2.0.0")
+implementation("io.github.extractpdf4j:extractpdf4j-service:2.1.0")
 ```
 
 ---
@@ -379,7 +367,7 @@ HybridParser ── coordinates and merges results from the above
 The CLI defaults to **hybrid mode**. If you do not pass `--mode`, it behaves like `--mode hybrid`.
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar input.pdf \
+java -jar extractpdf4j-cli-<version>.jar input.pdf \
   --pages all \
   --out tables.csv
 ```
@@ -401,7 +389,7 @@ See also the changelog entry for this documentation pass: [CHANGELOG](CHANGELOG.
 ## Project Status
 
 - Build tool: **Maven**
-- Coordinates (current): `io.github.extractpdf4j:extractpdf4j-parser:2.0.0`
+- Coordinates (current): `io.github.extractpdf4j:extractpdf4j-core:2.1.0`
 - Java: **17+** (recommended 17+ runtime)
 
 ---
@@ -426,7 +414,7 @@ See also the changelog entry for this documentation pass: [CHANGELOG](CHANGELOG.
 ```xml
 <dependency>
   <groupId>io.github.extractpdf4j</groupId>
-  <artifactId>extractpdf4j-parser</artifactId>
+  <artifactId>extractpdf4j-core</artifactId>
   <version>2.1.0</version>
 </dependency>
 ```
@@ -434,7 +422,7 @@ See also the changelog entry for this documentation pass: [CHANGELOG](CHANGELOG.
 ### Gradle
 
 ```kotlin
-implementation("io.github.extractpdf4j:extractpdf4j-parser:2.0.0")
+implementation("io.github.extractpdf4j:extractpdf4j-core:2.1.0")
 ```
 
 ### Native Notes
@@ -568,7 +556,7 @@ Run the bundled CLI to extract tables from a PDF.
 Usage:
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar <pdf>
+java -jar extractpdf4j-cli-<version>.jar <pdf>
      [--mode stream|lattice|ocrstream|hybrid]
      [--pages 1|all|1,3-5]
      [--sep ,]
@@ -592,8 +580,8 @@ java -jar extractpdf4j-parser-<version>.jar <pdf>
 Examples:
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar scan.pdf --mode lattice --pages 1 --dpi 450 --ocr cli --debug --keep-cells --debug-dir debug_out --out p1.csv
-java -jar extractpdf4j-parser-<version>.jar statement.pdf --mode hybrid --pages all --dpi 400 --out tables.csv
+java -jar extractpdf4j-cli-<version>.jar scan.pdf --mode lattice --pages 1 --dpi 450 --ocr cli --debug --keep-cells --debug-dir debug_out --out p1.csv
+java -jar extractpdf4j-cli-<version>.jar statement.pdf --mode hybrid --pages all --dpi 400 --out tables.csv
 ```
 
 Notes:
@@ -631,7 +619,7 @@ docker run -p 8080:8080 extractpdf4j-service
 Alternatively, you can run the service directly from the command line after building the project.
 
 ```bash
-java -jar target/extractpdf4j-parser-<version>.jar
+java -jar target/extractpdf4j-service-<version>.jar
 ```
 
 After running either command, you will see the Spring Boot application startup logs in your terminal.
@@ -788,7 +776,7 @@ Example (lattice, 450 DPI, CLI OCR, debug artifacts):
 
 ```bash
 java -Dtess.lang=eng -Dtess.psm=6 -Dtess.oem=1 -Docr.debug=true \
-  -jar extractpdf4j-parser-<version>.jar scan.pdf \
+  -jar extractpdf4j-cli-<version>.jar scan.pdf \
   --mode lattice --dpi 450 --ocr cli --debug --debug-dir debug \
   --out tables.csv
 ```

--- a/docs/advanced-usage/debug-images.md
+++ b/docs/advanced-usage/debug-images.md
@@ -49,7 +49,7 @@ public class DebugImagesExample {
 ## Typical CLI usage
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar scanned.pdf \
+java -jar extractpdf4j-cli-<version>.jar scanned.pdf \
   --mode lattice \
   --pages 1 \
   --dpi 300 \

--- a/docs/advanced-usage/ocr-tuning.md
+++ b/docs/advanced-usage/ocr-tuning.md
@@ -76,7 +76,7 @@ public class OcrTuningExample {
 ## Example: CLI
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar scan.pdf \
+java -jar extractpdf4j-cli-<version>.jar scan.pdf \
   --mode ocrstream \
   --pages 1-2 \
   --dpi 400 \

--- a/docs/advanced-usage/page-ranges.md
+++ b/docs/advanced-usage/page-ranges.md
@@ -66,7 +66,7 @@ public class PageRangesExample {
 ## Example: CLI
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar statement.pdf \
+java -jar extractpdf4j-cli-<version>.jar statement.pdf \
   --mode hybrid \
   --pages 2-4 \
   --out result.csv

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -13,8 +13,7 @@ The API is designed to give you:
 
 Depending on how you use the project, you may interact with one or more modules:
 
-- `extractpdf4j-parser` — parser implementations and extraction entry points
-- `extractpdf4j-core` — shared helpers and core data structures
+- `extractpdf4j-core` — parser implementations, extraction entry points, shared helpers, and core data structures
 - `extractpdf4j-cli` — command-line execution layer
 - `extractpdf4j-service` — service-oriented integration layer
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ That means it behaves like:
 ## Basic usage
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar input.pdf \
+java -jar extractpdf4j-cli-<version>.jar input.pdf \
   --pages all \
   --out tables.csv
 ```
@@ -98,7 +98,7 @@ Use these to tighten output control in more advanced workflows.
 ## Example: scanned PDF with lattice mode
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar scan.pdf \
+java -jar extractpdf4j-cli-<version>.jar scan.pdf \
   --mode lattice \
   --pages 1 \
   --dpi 450 \
@@ -112,7 +112,7 @@ java -jar extractpdf4j-parser-<version>.jar scan.pdf \
 ## Example: full-document hybrid extraction
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar statement.pdf \
+java -jar extractpdf4j-cli-<version>.jar statement.pdf \
   --mode hybrid \
   --pages all \
   --dpi 400 \

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -170,7 +170,7 @@ ExtractPDF4J includes CLI support for quick runs, scripting, and batch jobs.
 Example:
 
 ```bash
-java -jar extractpdf4j-parser-<version>.jar input.pdf \
+java -jar extractpdf4j-cli-<version>.jar input.pdf \
   --mode hybrid \
   --pages all \
   --out output.csv


### PR DESCRIPTION
### Motivation
- Bring documentation in line with the current module layout and published artifacts by standardizing examples to v2.1.0 and the `extractpdf4j-core`/`extractpdf4j-cli`/`extractpdf4j-service` modules. 
- Replace a stale `extractpdf4j-parser` artifact reference with the dedicated CLI artifact name so command examples match published jars. 
- Clarify the API overview so parser entry points are documented under `extractpdf4j-core` where they now reside. 

### Description
- Updated the README badge and dependency examples to reference version `2.1.0` and replaced obsolete `extractpdf4j-parser` examples. 
- Replaced all CLI invocation examples using `extractpdf4j-parser-<version>.jar` with `extractpdf4j-cli-<version>.jar` across README and `/docs` pages. 
- Adjusted Gradle/Maven snippets to reference `extractpdf4j-core`, `extractpdf4j-cli`, and `extractpdf4j-service` with consistent `2.1.0` coordinates. 
- Amended `docs/api/overview.md` to describe parser implementations and entry points under `extractpdf4j-core` and updated the service run example to use the service artifact. 

### Testing
- `mkdocs build --strict` completed successfully and produced the site without errors. 
- Documentation checks (`git diff --check`) reported no whitespace or diff problems. 
- `mvn test -q` was attempted but failed in this environment due to a Maven Central resolution error (HTTP 403) when fetching `org.springframework.boot:spring-boot-dependencies:pom:3.4.2` rather than due to code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ec4f878d88329ae055785e5de2686)