### PR TITLE
Bump project version to 2.2.0

### DIFF
--- a/extractpdf4j-bom/pom.xml
+++ b/extractpdf4j-bom/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.extractpdf4j</groupId>
         <artifactId>extractpdf4j-parser</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extractpdf4j-cli/pom.xml
+++ b/extractpdf4j-cli/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.extractpdf4j</groupId>
         <artifactId>extractpdf4j-parser</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
 
     <artifactId>extractpdf4j-cli</artifactId>

--- a/extractpdf4j-core/pom.xml
+++ b/extractpdf4j-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.extractpdf4j</groupId>
         <artifactId>extractpdf4j-parser</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
 
     <artifactId>extractpdf4j-core</artifactId>

--- a/extractpdf4j-service/pom.xml
+++ b/extractpdf4j-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.extractpdf4j</groupId>
         <artifactId>extractpdf4j-parser</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
 
     <artifactId>extractpdf4j-service</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.extractpdf4j</groupId>
     <artifactId>extractpdf4j-parser</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <packaging>pom</packaging>
 
     <name>ExtractPDF4J</name>


### PR DESCRIPTION
### Motivation
- Prepare the 2.2.0 release by aligning the root project and module parent versions to `2.2.0` so all modules build from the new release baseline.

### Description
- Updated the `<version>` in the root `pom.xml` from `2.1.0` to `2.2.0` and updated the parent `<version>` references in `extractpdf4j-bom/pom.xml`, `extractpdf4j-cli/pom.xml`, `extractpdf4j-core/pom.xml`, and `extractpdf4j-service/pom.xml` to `2.2.0`.
- Committed the changes with the message `Bump project version to 2.2.0`.

### Testing
- Ran `git diff --check` which completed with no whitespace issues.
- Ran `mvn -q validate` which failed to complete because Maven could not resolve `org.springframework.boot:spring-boot-dependencies:pom:3.4.2` due to an HTTP 403 (Forbidden) response from Maven Central in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ed05a172c8329bc0fae8a4208b5c7)