### PR TITLE
Add opt-in ML fallback for hybrid parsing

### DIFF
--- a/docs/advanced-usage/ml-fallback.md
+++ b/docs/advanced-usage/ml-fallback.md
@@ -1,0 +1,35 @@
+# Experimental ML fallback
+
+ExtractPDF4J can integrate a local machine-learning table extractor as an optional fallback without adding ML dependencies to the core module.
+
+The existing Stream, Lattice, and OCR strategies always run first. ML is invoked only when those strategies return no tables.
+
+```java
+MlTableExtractor extractor = new MyOnnxTableExtractor(modelPath);
+
+List<Table> tables = new HybridMlParser("statement.pdf", extractor)
+    .enableMlFallback(true)
+    .failOnMlError(false)
+    .dpi(300f)
+    .pages("all")
+    .parse();
+```
+
+`MlTableExtractor` is a lightweight SPI in `extractpdf4j-core`. Implementations should live in an optional module and may use ONNX Runtime, DJL, or another local inference engine.
+
+## Expected implementation responsibilities
+
+An ML extractor should:
+
+1. render the requested pages to images;
+2. detect table regions, rows, columns, headers, and spanning cells;
+3. reuse PDFBox or OCR word coordinates for text;
+4. assign words to predicted cells;
+5. return normal ExtractPDF4J `Table` objects;
+6. close model sessions and tensors safely.
+
+## Fallback behaviour
+
+By default, model-loading or inference failures do not fail the complete extraction. Set `failOnMlError(true)` when strict behaviour is required.
+
+ML is intentionally opt-in because model inference adds memory, latency, native dependencies, and model-distribution considerations. No document data needs to leave the local process.

--- a/extractpdf4j-core/src/main/java/com/extractpdf4j/ml/MlTableExtractor.java
+++ b/extractpdf4j-core/src/main/java/com/extractpdf4j/ml/MlTableExtractor.java
@@ -1,0 +1,36 @@
+package com.extractpdf4j.ml;
+
+import com.extractpdf4j.helpers.Table;
+import java.io.IOException;
+import java.util.List;
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+/**
+ * Optional machine-learning table extraction strategy used by hybrid parsing.
+ *
+ * <p>The core module owns only this lightweight contract. Implementations may
+ * live in an optional module and use ONNX Runtime or another local inference
+ * engine without adding ML dependencies to {@code extractpdf4j-core}.</p>
+ */
+public interface MlTableExtractor {
+
+    /**
+     * Extracts tables from a PDF file.
+     *
+     * @param filepath PDF path
+     * @param pages page selection using ExtractPDF4J syntax
+     * @return extracted tables, never {@code null}
+     * @throws IOException when the document or model cannot be processed
+     */
+    List<Table> extract(String filepath, String pages) throws IOException;
+
+    /**
+     * Extracts tables from an in-memory PDF document.
+     *
+     * @param document open PDFBox document owned by the caller
+     * @param pages page selection using ExtractPDF4J syntax
+     * @return extracted tables, never {@code null}
+     * @throws IOException when the document or model cannot be processed
+     */
+    List<Table> extract(PDDocument document, String pages) throws IOException;
+}

--- a/extractpdf4j-core/src/main/java/com/extractpdf4j/parsers/HybridMlParser.java
+++ b/extractpdf4j-core/src/main/java/com/extractpdf4j/parsers/HybridMlParser.java
@@ -1,0 +1,131 @@
+package com.extractpdf4j.parsers;
+
+import com.extractpdf4j.helpers.Table;
+import com.extractpdf4j.ml.MlTableExtractor;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+/**
+ * Experimental hybrid parser that invokes an injected ML extractor only when
+ * the existing Stream, Lattice, and OCR strategies return no tables.
+ *
+ * <p>This keeps ML optional and preserves the current deterministic parser
+ * behaviour. The ML implementation can live in a separate module and may use
+ * ONNX Runtime without introducing that dependency into the core module.</p>
+ */
+public class HybridMlParser extends HybridParser {
+
+    private final MlTableExtractor mlExtractor;
+    private boolean mlFallbackEnabled = true;
+    private boolean failOnMlError = false;
+
+    /**
+     * Creates an ML-enabled hybrid parser for a file.
+     *
+     * @param filepath PDF path
+     * @param mlExtractor optional ML extraction strategy
+     */
+    public HybridMlParser(String filepath, MlTableExtractor mlExtractor) {
+        super(filepath);
+        this.mlExtractor = Objects.requireNonNull(mlExtractor, "mlExtractor");
+    }
+
+    /**
+     * Creates an ML-enabled parser for in-memory PDFBox documents.
+     *
+     * @param mlExtractor optional ML extraction strategy
+     */
+    public HybridMlParser(MlTableExtractor mlExtractor) {
+        super();
+        this.mlExtractor = Objects.requireNonNull(mlExtractor, "mlExtractor");
+    }
+
+    /** Enables or disables ML fallback. Enabled by default for this parser. */
+    public HybridMlParser enableMlFallback(boolean enabled) {
+        this.mlFallbackEnabled = enabled;
+        return this;
+    }
+
+    /**
+     * Controls whether ML inference errors fail parsing or fall back to an
+     * empty ML result. The default is {@code false}.
+     */
+    public HybridMlParser failOnMlError(boolean enabled) {
+        this.failOnMlError = enabled;
+        return this;
+    }
+
+    @Override
+    public HybridMlParser pages(String pages) {
+        super.pages(pages);
+        return this;
+    }
+
+    @Override
+    public HybridMlParser dpi(float dpi) {
+        super.dpi(dpi);
+        return this;
+    }
+
+    @Override
+    public HybridMlParser debug(boolean enabled) {
+        super.debug(enabled);
+        return this;
+    }
+
+    @Override
+    public HybridMlParser stripText(boolean strip) {
+        super.stripText(strip);
+        return this;
+    }
+
+    @Override
+    protected List<Table> parsePage(int page) throws IOException {
+        List<Table> ruleBased = super.parsePage(page);
+        if (!mlFallbackEnabled || (ruleBased != null && !ruleBased.isEmpty())) {
+            return ruleBased;
+        }
+
+        String pageSelection = page == -1 ? pages : String.valueOf(page);
+        try {
+            List<Table> mlTables = mlExtractor.extract(filepath, pageSelection);
+            return mlTables == null ? Collections.emptyList() : mlTables;
+        } catch (IOException ex) {
+            if (failOnMlError) {
+                throw ex;
+            }
+            return Collections.emptyList();
+        } catch (RuntimeException ex) {
+            if (failOnMlError) {
+                throw new IOException("ML table extraction failed", ex);
+            }
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public List<Table> parse(PDDocument document) throws IOException {
+        List<Table> ruleBased = super.parse(document);
+        if (!mlFallbackEnabled || (ruleBased != null && !ruleBased.isEmpty())) {
+            return ruleBased;
+        }
+
+        try {
+            List<Table> mlTables = mlExtractor.extract(document, pages);
+            return mlTables == null ? Collections.emptyList() : mlTables;
+        } catch (IOException ex) {
+            if (failOnMlError) {
+                throw ex;
+            }
+            return Collections.emptyList();
+        } catch (RuntimeException ex) {
+            if (failOnMlError) {
+                throw new IOException("ML table extraction failed", ex);
+            }
+            return Collections.emptyList();
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Added a lightweight `MlTableExtractor` SPI to `extractpdf4j-core`.
- Added experimental `HybridMlParser`, which runs the existing Stream, Lattice, and OCR strategies first and invokes ML only when they return no tables.
- Added configurable fail-open/fail-closed behaviour for inference errors.
- Added documentation and a usage example for local ONNX/DJL implementations.

## Why

This introduces the Hybrid integration point without coupling the core library to ONNX Runtime or forcing model dependencies on existing users. It preserves current parser behaviour and makes ML fully opt-in.

## Behaviour

```java
MlTableExtractor extractor = new MyOnnxTableExtractor(modelPath);

List<Table> tables = new HybridMlParser("statement.pdf", extractor)
    .enableMlFallback(true)
    .failOnMlError(false)
    .pages("all")
    .parse();
```

The deterministic parsers remain first. ML runs only when they produce no tables.

## Validation

The branch was reviewed through the repository connector and is limited to three new files. I could not run the Maven build in the execution environment because direct repository checkout/network access was unavailable.

## Follow-up

A separate focused PR should add the optional `extractpdf4j-ml` module with ONNX Runtime, model preprocessing/postprocessing, word-to-cell mapping, debug overlays, and model-backed integration tests.